### PR TITLE
feat: update to esbuild 0.17+

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esbuild-os-notifier",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "Esbuild OS Notification Plugin",
   "main": "dist/index.js",
   "repository": "https://danielperez9430@github.com/danielperez9430/esbuild-os-notifier.git",
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "deepmerge": "^4.2.2",
-    "esbuild": "^0.15.9",
+    "esbuild": "^0.17.19",
     "node-notifier": "^10.0.1"
   },
   "devDependencies": {
@@ -33,6 +33,7 @@
     "@rollup/plugin-typescript": "^8.5.0",
     "@types/node-notifier": "^8.0.2",
     "rollup": "^2.79.1",
+    "tslib": "^2.6.3",
     "typescript": "^4.8.3"
   }
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,10 +30,6 @@ export default function esbuildOsNotifier(notificationOptions: NotificationCente
                 sucess: true,
             }, show)
 
-            if (!build.initialOptions.watch) {
-                return false
-            }
-
             let start = 0
 
             build.onStart(() => {


### PR DESCRIPTION
Esbuild version 0.17 ([see changelog](https://github.com/evanw/esbuild/releases/tag/v0.17.0)) dropped support for the `watch` variable in "build.initialOptions.watch". In situations where a current version of esbuild is used, esbuild-os-notifier will stop working entirely. 

The attached PR therefore:
* removes the problematic line
* updates esbuild dependency to version 0.17.19
* updates esbuild-os-notifier version to 1.1.0