### PR TITLE
Fixes typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esbuild-os-notifier",
-  "version": "1.0.4",
+  "version": "1.1.0",
   "description": "Esbuild OS Notification Plugin",
   "main": "dist/index.js",
   "repository": "https://danielperez9430@github.com/danielperez9430/esbuild-os-notifier.git",
@@ -24,7 +24,7 @@
   },
   "dependencies": {
     "deepmerge": "^4.2.2",
-    "esbuild": "^0.15.9",
+    "esbuild": "^0.17.19",
     "node-notifier": "^10.0.1"
   },
   "devDependencies": {
@@ -33,6 +33,7 @@
     "@rollup/plugin-typescript": "^8.5.0",
     "@types/node-notifier": "^8.0.2",
     "rollup": "^2.79.1",
+    "tslib": "^2.6.3",
     "typescript": "^4.8.3"
   }
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "esbuild-os-notifier",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Esbuild OS Notification Plugin",
   "main": "dist/index.js",
   "repository": "https://danielperez9430@github.com/danielperez9430/esbuild-os-notifier.git",

--- a/src/index.ts
+++ b/src/index.ts
@@ -24,11 +24,11 @@ export default function esbuildOsNotifier(notificationOptions: NotificationCente
         name: 'esbuild-build-os-notifications',
         setup(build: PluginBuild) {
 
-            const display = deepmerge({
+            const display: ShowOptions = deepmerge({
                 warnings: true,
                 errors: true,
-                sucess: true,
-            }, show)
+                success: true,
+            } satisfies ShowOptions, show)
 
             let start = 0
 
@@ -67,7 +67,7 @@ export default function esbuildOsNotifier(notificationOptions: NotificationCente
                     })
                 }
 
-                if ((!errors || errors?.length === 0) && display.sucess) {
+                if ((!errors || errors?.length === 0) && display.success) {
                     sendMessage("✅ Build successfull!", deepmerge({
                         title: 'Esbuild',
                         timeout: 5

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,10 +30,6 @@ export default function esbuildOsNotifier(notificationOptions: NotificationCente
                 sucess: true,
             }, show)
 
-            if (!build.initialOptions.watch) {
-                return false
-            }
-
             let start = 0
 
             build.onStart(() => {


### PR DESCRIPTION
Sorry, it's me once again :D 

I wanted to use the plugin in my project and found that the ShowOptions parameter was not working. Turns out that there is a small typo in index.ts ("sucess" instead of "success"). I have made the type more clear, fixed the typo, and increased the version number. 